### PR TITLE
Implementación del content provider, peticiones desde la aplicación cliente y muestra de datos en la app cliente

### DIFF
--- a/exchange-rate-backend/app/src/main/AndroidManifest.xml
+++ b/exchange-rate-backend/app/src/main/AndroidManifest.xml
@@ -34,6 +34,13 @@
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="remove" />
+
+        <provider
+            android:name=".providers.ExchangeRateProvider"
+            android:authorities="com.example.exchangeRate.providers"
+            android:exported="true"
+            android:permission="com.example.exchangeRate.permission.READ_EXCHANGE_RATES">
+        </provider>
     </application>
 
 </manifest>

--- a/exchange-rate-backend/app/src/main/AndroidManifest.xml
+++ b/exchange-rate-backend/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <!-- Permiso de Internet -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <permission
+        android:name="com.example.exchangeRate.permission.READ_EXCHANGE_RATES"
+        android:protectionLevel="normal" />
 
     <application
         android:name=".ExchangeRateApplication"

--- a/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/data/ExchangeRateDao.kt
+++ b/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/data/ExchangeRateDao.kt
@@ -19,10 +19,11 @@ interface ExchangeRateDao {
     fun getLatestExchangeRate(): Flow<ExchangeRate?>
 
     // Obtiene todos los registros dentro de un rango de fechas específico
-    @Query("SELECT * FROM exchange_rates WHERE syncDate BETWEEN :startDate AND :endDate ORDER BY syncDate DESC")
+    @Query("SELECT rates, lastUpdateUnix, lastUpdateUnix FROM exchange_rates WHERE lastUpdateUnix >= :startDate AND lastUpdateUnix <= :endDate ORDER BY lastUpdateUnix ASC")
     fun getExchangeRatesByDateRange(startDate: Long, endDate: Long): Flow<List<ExchangeRate>>
 
     // Elimina todos los registros de la tabla (útil para limpiar la tabla)
     @Query("DELETE FROM exchange_rates")
     suspend fun deleteAll()
+
 }

--- a/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/data/ExchangeRateDao.kt
+++ b/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/data/ExchangeRateDao.kt
@@ -19,7 +19,7 @@ interface ExchangeRateDao {
     fun getLatestExchangeRate(): Flow<ExchangeRate?>
 
     // Obtiene todos los registros dentro de un rango de fechas específico
-    @Query("SELECT rates, lastUpdateUnix, lastUpdateUnix FROM exchange_rates WHERE lastUpdateUnix >= :startDate AND lastUpdateUnix <= :endDate ORDER BY lastUpdateUnix ASC")
+    @Query("SELECT * FROM exchange_rates WHERE syncDate BETWEEN :startDate AND :endDate ORDER BY lastUpdateUnix ASC")
     fun getExchangeRatesByDateRange(startDate: Long, endDate: Long): Flow<List<ExchangeRate>>
 
     // Elimina todos los registros de la tabla (útil para limpiar la tabla)

--- a/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/data/ExchangeRateRepository.kt
+++ b/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/data/ExchangeRateRepository.kt
@@ -69,4 +69,6 @@ class ExchangeRateRepository(
             Log.e("ExchangeRateRepository", "Error al sincronizar los datos: ${e.message}")
         }
     }
+
+
 }

--- a/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/providers/ExchangeRateProvider.kt
+++ b/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/providers/ExchangeRateProvider.kt
@@ -1,0 +1,99 @@
+package com.example.exchangeRate.providers
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.UriMatcher
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.util.Log
+import com.example.exchangeRate.ExchangeRateApplication
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+private val sUriMatcher = UriMatcher(UriMatcher.NO_MATCH).apply {
+    addURI("com.example.exchangeRate.providers", "exchange_rates_by_date_range", 1)
+}
+
+class ExchangeRateProvider  : ContentProvider() {
+    override fun onCreate(): Boolean {
+        return true
+    }
+
+    // Define un CoroutineScope para manejar las coroutines
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? {
+        val cursor = MatrixCursor(arrayOf("rates", "last_update_unix", "next_update_unix"))
+        val deferredResult = CompletableDeferred<Cursor?>()
+
+        // Obtener los parámetros de la consulta
+        val startDate = selectionArgs?.get(0)?.toLongOrNull()
+            ?: throw IllegalArgumentException("Start date is required")
+        val endDate = selectionArgs?.get(1)?.toLongOrNull()
+            ?: throw IllegalArgumentException("End date is required")
+
+        when (sUriMatcher.match(uri)) {
+            1 -> scope.launch {
+                try {
+                    Log.d("ExchangeRateProvider", "Trying to get data")
+                    val exchangeRates = (context as ExchangeRateApplication)
+                        .container.exchangeRateRepository
+                        .getExchangeRatesByDateRange(startDate, endDate)
+                        .first()
+
+                    // Agregar los datos al cursor
+                    exchangeRates.forEach { exchangeRate ->
+                        cursor.addRow(
+                            arrayOf(
+                                exchangeRate.rates.toString(), // Convertir el mapa a String
+                                exchangeRate.lastUpdateUnix,
+                                exchangeRate.nextUpdateUnix
+                            )
+                        )
+                    }
+                    Log.d("ExchangeRateProvider", "Data retrieved: ${cursor.count} rows")
+                    deferredResult.complete(cursor)
+                } catch (e: Exception) {
+                    Log.e("ExchangeRateProvider", "Error retrieving exchange rates", e)
+                    deferredResult.completeExceptionally(e)
+                }
+            }
+            else -> throw IllegalArgumentException("Unknown URI: $uri")
+        }
+
+        // Esperar el resultado de la coroutine
+        return runBlocking {
+            deferredResult.await()
+        }
+    }
+
+    override fun getType(uri: Uri): String? {
+        return when (sUriMatcher.match(uri)) {
+            1 -> "vnd.android.cursor.dir/vnd.com.example.exchangeRate.providers.exchange_rates_by_date_range"
+            else -> throw IllegalArgumentException("Unknown URI: $uri")
+        }
+    }
+
+    override fun insert(p0: Uri, p1: ContentValues?): Uri? {
+        return  null
+    }
+
+    override fun delete(p0: Uri, p1: String?, p2: Array<out String>?): Int {
+        return  0
+    }
+
+    override fun update(p0: Uri, p1: ContentValues?, p2: String?, p3: Array<out String>?): Int {
+        return  0
+    }
+}

--- a/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/ui/screens/ExchangeRateViewModel.kt
+++ b/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/ui/screens/ExchangeRateViewModel.kt
@@ -12,11 +12,19 @@ import com.example.exchangeRate.data.ExchangeRateRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+
+
+import java.text.SimpleDateFormat
+import java.util.*
 
 class ExchangeRateViewModel(
     private val repository: ExchangeRateRepository
 ) : ViewModel() {
+
+
+    val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
 
     // Estado para las tasas de conversión
     private val _conversionRates = MutableStateFlow<Map<String, Double>>(emptyMap())
@@ -52,7 +60,7 @@ class ExchangeRateViewModel(
             _isLoading.value = true
             _errorMessage.value = ""
             try {
-                repository.syncExchangeRates()
+                //repository.syncExchangeRates()
                 // Log para verificar que la carga se completó correctamente
                 Log.d("ExchangeRateViewModel", "Carga de datos completada")
             } catch (e: Exception) {
@@ -63,6 +71,34 @@ class ExchangeRateViewModel(
                 _isLoading.value = false
                 // Log para verificar que la carga terminó (éxito o error)
                 Log.d("ExchangeRateViewModel", "Carga de datos finalizada")
+            }
+        }
+    }
+
+    // Función de prueba para verificar la consulta del rango de fechas
+    fun testDateRangeQuery(startDate: Long, endDate: Long) {
+        viewModelScope.launch {
+            try {
+                val startFormatted = dateFormat.format(Date(startDate))
+                val endFormatted = dateFormat.format(Date(endDate))
+
+                Log.d("ExchangeRateViewModel", "Fechas: $startFormatted - $endFormatted")
+                // Ejecutar la consulta del rango de fechas
+                val exchangeRates = repository.getExchangeRatesByDateRange(startDate, endDate).first()
+
+                // Imprimir los resultados en el log
+                Log.d("ExchangeRateViewModel", "Resultados de la consulta del rango de fechas:")
+                exchangeRates.forEach { exchangeRate ->
+                    Log.d("ExchangeRateViewModel", "ExchangeRate: $exchangeRate")
+                }
+
+                // Verificar si no se devolvieron datos
+                if (exchangeRates.isEmpty()) {
+                    Log.d("ExchangeRateViewModel", "No se encontraron datos en el rango de fechas especificado.")
+                }
+            } catch (e: Exception) {
+                // Log en caso de error
+                Log.e("ExchangeRateViewModel", "Error en testDateRangeQuery: ${e.message}")
             }
         }
     }

--- a/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/ui/screens/MainScreen.kt
+++ b/exchange-rate-backend/app/src/main/java/com/example/exchangeRate/ui/screens/MainScreen.kt
@@ -31,6 +31,13 @@ fun MainScreen(
     Log.d("MainScreen", "Estado de carga: $isLoading")
     Log.d("MainScreen", "Mensaje de error: $errorMessage")
 
+    // Define el rango de fechas (por ejemplo, últimos 7 días)
+    val startDate = System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000) // Hace 7 días
+    val endDate = System.currentTimeMillis() // Fecha actual
+
+// Llama a la función de prueba
+    viewModel.testDateRangeQuery(startDate, endDate + 1000)
+
 
     Column(
         modifier = Modifier

--- a/exchange-rate-client/app/src/main/AndroidManifest.xml
+++ b/exchange-rate-client/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Solicita el permiso -->
+    <uses-permission android:name="com.example.exchangeRate.permission.READ_EXCHANGE_RATES" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"


### PR DESCRIPTION
- Se registró el ContentProvider en el manifest de la aplicación proveedora.
- Se detallaron permisos para lectura del proveedor de contenido tanto en la aplicación proveedora como en la aplicación cliente.
- Se creó el ContentProvider en la aplicación proveedora.
- Se corrigieron algunas consultas del DAO de la aplicación proveedora por un error lógico que hacía que el rango de fechas fuera siempre inválido.
- Se agregaron algunos métodos para testear las consultas a la base de datos.
- Se agregaron mecanismos para mostrar datos en la aplicación cliente provenientes de la aplicación proveedora.